### PR TITLE
Switched to working mirror for MariaDB 10.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,13 @@ env:
   - PLAYBOOK=test.yml
 
 before_install:
-  - sudo apt-get update -qq
-  
+  # Remove any MySQL package to ensure a clean starting state
+  - sudo apt-get remove --purge 'mysql*'
+  - sudo apt-get autoremove
+  - sudo apt-get autoclean
+  - sudo rm -rf /var/lib/mysql
+  - sudo truncate -s 0 /var/log/mysql/error.log
+
 install:
   # Install Ansible.
   - pip install ansible
@@ -28,3 +33,17 @@ script:
     | grep -q 'changed=0.*failed=0'
     && (echo 'Idempotence test: pass' && exit 0)
     || (echo 'Idempotence test: fail' && exit 1)
+
+  # Check to make sure we can connect to MySQL via Unix socket.
+  - >
+    mysql -u root -proot -e 'show databases;'
+    | grep -q 'performance_schema'
+    && (echo 'MySQL running normally' && exit 0)
+    || (echo 'MySQL not running' && exit 1)
+
+  # Check to make sure we can connect to MySQL via TCP.
+  - >
+    mysql -u root -proot -h 127.0.0.1 -e 'show databases;'
+    | grep -q 'performance_schema'
+    && (echo 'MySQL running normally' && exit 0)
+    || (echo 'MySQL not running' && exit 1)

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,7 +5,7 @@
 
 - name: Add MariaDB-Repository
   sudo: yes
-  apt_repository: repo='deb http://mirror3.layerjet.com/mariadb/repo/10.1/ubuntu {{ ansible_distribution_release }} main' state=present
+  apt_repository: repo='deb http://ftp.ddg.lth.se/mariadb/repo/10.1/ubuntu {{ ansible_distribution_release }} main' state=present
 
 - name: Add Key for MariaDB Repository
   sudo: yes


### PR DESCRIPTION
Noticed that I got MariaDB 5.5 on an install. When I investigated this it seems the layerjet.com server had gone down and I must have been served the default MariaDB version in trusty.

Changed the repo URL to one from a large swedish university - very unlikely to get shut down in the foreseeable future. After a fresh `vagrant up` I got 10.1 as expected.
